### PR TITLE
rename build artifacts directory

### DIFF
--- a/elm/sum.html
+++ b/elm/sum.html
@@ -7,6 +7,6 @@
 <title>My cashbook</title>
 </head>
 <body>
-<script type="text/javascript" src="/dist/bundle.js"></script>
+<script type="text/javascript" src="/app/bundle.js"></script>
 </body>
 </html>

--- a/elm/webpack.config.js
+++ b/elm/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   entry: './src/index.js',
   output: {
-    path: './dist/',
+    path: './app/',
     filename: 'bundle.js'
   },
   resolve: {


### PR DESCRIPTION
dist/ is ignored by my phone's Dropsync configuration. So it's inconvinient to install the app in my phone.
